### PR TITLE
fix progress bar not showing when delayed writing

### DIFF
--- a/app/linuxdrivemanager.cpp
+++ b/app/linuxdrivemanager.cpp
@@ -228,8 +228,6 @@ bool LinuxDrive::write(ReleaseVariant *data) {
     connect(m_process, &QProcess::errorOccurred, this, &LinuxDrive::onErrorOccurred);
 #endif
 
-    m_progress->setTo(data->size());
-    m_progress->setValue(0.0/0.0);
     m_process->start(QIODevice::ReadOnly);
 
     return true;
@@ -295,6 +293,9 @@ void LinuxDrive::restore() {
 void LinuxDrive::onReadyRead() {
     if (!m_process)
         return;
+
+    m_progress->setTo(data->size());
+    m_progress->setValue(0.0/0.0);
 
     if (m_image->status() != ReleaseVariant::WRITE_VERIFYING && m_image->status() != ReleaseVariant::WRITING)
         m_image->setStatus(ReleaseVariant::WRITING);

--- a/app/macdrivemanager.cpp
+++ b/app/macdrivemanager.cpp
@@ -109,8 +109,6 @@ bool MacDrive::write(ReleaseVariant *data) {
     command.append(" write ");
     if (data->status() == ReleaseVariant::WRITING) {
         command.append(QString("'%1'").arg(data->iso()));
-        m_progress->setTo(data->size());
-        m_progress->setValue(0.0/0.0);
     }
     else {
         command.append(QString("'%1'").arg(data->temporaryPath()));
@@ -224,6 +222,11 @@ void MacDrive::onRestoreFinished(int exitCode, QProcess::ExitStatus exitStatus) 
 void MacDrive::onReadyRead() {
     if (!m_child)
         return;
+
+    if (m_image->status() == ReleaseVariant::WRITING) {
+        m_progress->setTo(m_image->size());
+        m_progress->setValue(0.0/0.0);
+    }
 
     if (m_image->status() != ReleaseVariant::WRITE_VERIFYING && m_image->status() != ReleaseVariant::WRITING)
         m_image->setStatus(ReleaseVariant::WRITING);

--- a/app/windrivemanager.cpp
+++ b/app/windrivemanager.cpp
@@ -281,9 +281,6 @@ bool WinDrive::write(ReleaseVariant *data) {
     args << QString("%1").arg(m_device);
     m_child->setArguments(args);
 
-    m_progress->setTo(data->size());
-    m_progress->setValue(NAN);
-
     mDebug() << this->metaObject()->className() << "Starting" << m_child->program() << args;
     m_child->start();
     return true;
@@ -382,6 +379,9 @@ void WinDrive::onRestoreFinished(int exitCode, QProcess::ExitStatus exitStatus) 
 void WinDrive::onReadyRead() {
     if (!m_child)
         return;
+
+    m_progress->setTo(m_image->size());
+    m_progress->setValue(NAN);
 
     if (m_image->status() != ReleaseVariant::WRITE_VERIFYING && m_image->status() != ReleaseVariant::WRITING)
         m_image->setStatus(ReleaseVariant::WRITING);


### PR DESCRIPTION
Moved calls to progress bar setTo and setValue from DriveManager::write()  to DriveManager::onReadyRead().
Takes care of the case where delayedWrite() calls write() too early before file size is known causing the "to" value to be 0 and progress bar value to be invalid for the whole writing process.
