### PR TITLE
appdata.xml: add content_rating & releases

### DIFF
--- a/dist/linux/mediawriter.appdata.xml
+++ b/dist/linux/mediawriter.appdata.xml
@@ -144,4 +144,8 @@
 		<screenshot>https://github.com/MartinBriza/MediaWriter/raw/master/dist/screenshots/details.png</screenshot>
 	</screenshots>
 	<update_contact>mbriza@redhat.com</update_contact>
+	<content_rating type="oars-1.1"/>
+	<releases>
+		<release version="4.1.4" date="2019-05-02"/>
+	</releases>
 </application>

--- a/dist/linux/mediawriter.appdata.xml.in
+++ b/dist/linux/mediawriter.appdata.xml.in
@@ -27,4 +27,8 @@
 		<screenshot>https://github.com/MartinBriza/MediaWriter/raw/master/dist/screenshots/details.png</screenshot>
 	</screenshots>
 	<update_contact>mbriza@redhat.com</update_contact>
+	<content_rating type="oars-1.1"/>
+	<releases>
+		<release version="4.1.4" date="2019-05-02"/>
+	</releases>
 </application>


### PR DESCRIPTION
fixes:
```
$ flatpak run org.freedesktop.appstream-glib validate mediawriter.appdata.xml
mediawriter.appdata.xml: FAILED:
• tag-missing           : <content_rating> required [use https://odrs.gnome.org/oars]
• tag-missing           : <release> required
```