### PR TITLE
Use OpenDevice Udisks2 dbus call, instead of OpenForBenchmark

### DIFF
--- a/helper/linux/writejob.cpp
+++ b/helper/linux/writejob.cpp
@@ -95,7 +95,7 @@ QDBusUnixFileDescriptor WriteJob::getDescriptor() {
         return QDBusUnixFileDescriptor(-1);
     }
 
-    QDBusReply<QDBusUnixFileDescriptor> reply = device.callWithArgumentList(QDBus::Block, "OpenForBenchmark", {Properties{{"writable", true}}} );
+    QDBusReply<QDBusUnixFileDescriptor> reply = device.call(QDBus::Block, "OpenDevice", "rw", Properties{} );
     QDBusUnixFileDescriptor fd = reply.value();
 
     if (!fd.isValid()) {


### PR DESCRIPTION
`OpenForBenchmark` is [deprecated][1], and [led to a confusing and inaccurate prompt][2]. So `OpenDevice` is the correct method.

[1]: http://storaged.org/doc/udisks2-api/latest/gdbus-org.freedesktop.UDisks2.Block.html#gdbus-method-org-freedesktop-UDisks2-Block.OpenForBenchmark
[2]: https://github.com/FedoraQt/MediaWriter/issues/119