### PR TITLE
Add keywords to .desktop

### DIFF
--- a/src/app/data/org.fedoraproject.MediaWriter.desktop
+++ b/src/app/data/org.fedoraproject.MediaWriter.desktop
@@ -73,4 +73,5 @@ Icon=org.fedoraproject.MediaWriter
 Exec=mediawriter
 Terminal=false
 Categories=System;
+Keywords=fmw;usb;iso;bootable;
 

--- a/src/app/data/org.fedoraproject.MediaWriter.desktop.in
+++ b/src/app/data/org.fedoraproject.MediaWriter.desktop.in
@@ -6,4 +6,5 @@ Icon=org.fedoraproject.MediaWriter
 Exec=mediawriter
 Terminal=false
 Categories=System;
+Keywords=fmw;usb;iso;bootable;
 


### PR DESCRIPTION
This makes FMW easier to find using the words 'fmw,usb,iso,bootable'

Closes: #291 