### PR TITLE
Add fmw as keyword to .desktop

### DIFF
--- a/src/app/data/org.fedoraproject.MediaWriter.desktop
+++ b/src/app/data/org.fedoraproject.MediaWriter.desktop
@@ -73,4 +73,5 @@ Icon=org.fedoraproject.MediaWriter
 Exec=mediawriter
 Terminal=false
 Categories=System;
+Keywords=fmw;
 

--- a/src/app/data/org.fedoraproject.MediaWriter.desktop.in
+++ b/src/app/data/org.fedoraproject.MediaWriter.desktop.in
@@ -6,4 +6,5 @@ Icon=org.fedoraproject.MediaWriter
 Exec=mediawriter
 Terminal=false
 Categories=System;
+Keywords=fmw;
 


### PR DESCRIPTION
This makes FMW easier to find using Gnome search.

Fixes: https://github.com/FedoraQt/MediaWriter/issues/291


See #293 for even more keywords. I'd prefer #293 to be merged and this PR to be closed but that is up to you.