### PR TITLE
Use portal file dialog when possible to avoid native dialog issues

### DIFF
--- a/src/app/CMakeLists.txt
+++ b/src/app/CMakeLists.txt
@@ -12,6 +12,7 @@ set(MEDIAWRITER_SRCS
     fakedrivemanager.cpp
     main.cpp
     notifications.cpp
+    portalfiledialog.cpp
     releasemanager.cpp
     units.cpp
     utilities.cpp

--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -32,6 +32,7 @@
 #include "crashhandler.h"
 #include "drivemanager.h"
 #include "icon.h"
+#include "portalfiledialog.h"
 #include "releasemanager.h"
 #include "units.h"
 #include "versionchecker.h"
@@ -50,8 +51,6 @@ Q_IMPORT_PLUGIN(QtQuickLayoutsPlugin);
 Q_IMPORT_PLUGIN(QmlFolderListModelPlugin);
 Q_IMPORT_PLUGIN(QmlSettingsPlugin);
 #endif
-
-#include <QDebug>
 
 int main(int argc, char **argv)
 {
@@ -96,8 +95,10 @@ int main(int argc, char **argv)
 
     mDebug() << "Injecting QML context properties";
     QQmlApplicationEngine engine;
+
     engine.rootContext()->setContextProperty("downloadManager", DownloadManager::instance());
     engine.rootContext()->setContextProperty("drives", DriveManager::instance());
+    engine.rootContext()->setContextProperty("portalFileDialog", new PortalFileDialog(&app));
     engine.rootContext()->setContextProperty("mediawriterVersion", MEDIAWRITER_VERSION);
     engine.rootContext()->setContextProperty("releases", new ReleaseManager());
     engine.rootContext()->setContextProperty("units", Units::instance());

--- a/src/app/portalfiledialog.cpp
+++ b/src/app/portalfiledialog.cpp
@@ -1,0 +1,195 @@
+/*
+ * Fedora Media Writer
+ * Copyright (C) 2021 Jan Grulich <jgrulich@redhat.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+#include "portalfiledialog.h"
+#include "utilities.h"
+
+#include <QGuiApplication>
+#include <QRandomGenerator>
+#include <QFileDialog>
+#include <QStandardPaths>
+
+#ifdef __linux
+#include <QtDBus/QtDBus>
+#include <QDBusConnection>
+#include <QDBusConnectionInterface>
+#include <QDBusMessage>
+#include <QDBusPendingCall>
+#include <QDBusPendingCallWatcher>
+#include <QDBusPendingReply>
+
+// Copied from PortalFileDialog
+QDBusArgument &operator <<(QDBusArgument &arg, const PortalFileDialog::FilterCondition &filterCondition)
+{
+    arg.beginStructure();
+    arg << filterCondition.type << filterCondition.pattern;
+    arg.endStructure();
+    return arg;
+}
+const QDBusArgument &operator >>(const QDBusArgument &arg, PortalFileDialog::FilterCondition &filterCondition)
+{
+    uint type;
+    QString filterPattern;
+    arg.beginStructure();
+    arg >> type >> filterPattern;
+    filterCondition.type = (PortalFileDialog::ConditionType)type;
+    filterCondition.pattern = filterPattern;
+    arg.endStructure();
+    return arg;
+}
+QDBusArgument &operator <<(QDBusArgument &arg, const PortalFileDialog::Filter filter)
+{
+    arg.beginStructure();
+    arg << filter.name << filter.filterConditions;
+    arg.endStructure();
+    return arg;
+}
+const QDBusArgument &operator >>(const QDBusArgument &arg, PortalFileDialog::Filter &filter)
+{
+    QString name;
+    PortalFileDialog::FilterConditionList filterConditions;
+    arg.beginStructure();
+    arg >> name >> filterConditions;
+    filter.name = name;
+    filter.filterConditions = filterConditions;
+    arg.endStructure();
+    return arg;
+}
+#endif
+
+static inline bool checkSandboxEnvironment()
+{
+    return !QStandardPaths::locate(QStandardPaths::RuntimeLocation, QStringLiteral("flatpak-info")).isEmpty() || qEnvironmentVariableIsSet("SNAP");
+}
+
+PortalFileDialog::PortalFileDialog(QObject *parent, WId winId)
+    : QObject(parent)
+    , m_winId(winId)
+{
+#ifdef __linux
+    QDBusConnectionInterface *interface = QDBusConnection::sessionBus().interface();
+    m_available = interface->isServiceRegistered(QStringLiteral("org.freedesktop.portal.Desktop"));
+
+    // In case we are in sandbox we can use native dialog which will already use portals
+    if (m_available) {
+        m_available = !checkSandboxEnvironment();
+    }
+#endif
+}
+
+PortalFileDialog::~PortalFileDialog()
+{
+}
+
+bool PortalFileDialog::isAvailable() const
+{
+#ifdef __linux
+    return m_available;
+#else
+    return false;
+#endif
+}
+
+void PortalFileDialog::open()
+{
+    if (!m_available) {
+        return;
+    }
+
+#ifdef __linux
+    QDBusMessage message = QDBusMessage::createMethodCall(QStringLiteral("org.freedesktop.portal.Desktop"),
+                                                          QStringLiteral("/org/freedesktop/portal/desktop"),
+                                                          QStringLiteral("org.freedesktop.portal.FileChooser"),
+                                                          QStringLiteral("OpenFile"));
+    QVariantMap options;
+    options.insert(QStringLiteral("modal"), true);
+    options.insert(QStringLiteral("handle_token"), QStringLiteral("qt%1").arg(QRandomGenerator::global()->generate()));
+    options.insert(QStringLiteral("multiple"), false);
+
+    qDBusRegisterMetaType<FilterCondition>();
+    qDBusRegisterMetaType<FilterConditionList>();
+    qDBusRegisterMetaType<Filter>();
+    qDBusRegisterMetaType<FilterList>();
+
+    FilterList filterList;
+
+    FilterConditionList filterConditions1;
+    FilterCondition filterCondition1;
+    filterCondition1.type = GlobalPattern;
+    filterCondition1.pattern = QStringLiteral("*.iso");
+    FilterCondition filterCondition2;
+    filterCondition2.type = GlobalPattern;
+    filterCondition2.pattern = QStringLiteral("*.raw");
+    FilterCondition filterCondition3;
+    filterCondition3.type = GlobalPattern;
+    filterCondition3.pattern = QStringLiteral("*.xz");
+    filterConditions1 << filterCondition1 << filterCondition2 << filterCondition3;
+
+    Filter filter1;
+    filter1.name = tr("Image files");
+    filter1.filterConditions = filterConditions1;
+
+    FilterConditionList filterConditions2;
+    FilterCondition filterCondition4;
+    filterCondition4.type = GlobalPattern;
+    filterCondition4.pattern = QStringLiteral("*");
+    filterConditions2 << filterCondition4;
+
+    Filter filter2;
+    filter2.name = tr("All files");
+    filter2.filterConditions = filterConditions2;
+
+    filterList << filter1 << filter2;
+
+    options.insert(QLatin1String("filters"), QVariant::fromValue(filterList));
+
+    const QString parentWindow = QGuiApplication::platformName() == QStringLiteral("xcb") ? QStringLiteral("x11:%1").arg(QString::number(m_winId)) :
+                                                                                            QStringLiteral("wayland:%1").arg(QString::number(m_winId));
+
+    message << parentWindow << tr("Open File") << options;
+
+    QDBusPendingCall pendingCall = QDBusConnection::sessionBus().asyncCall(message);
+    QDBusPendingCallWatcher *watcher = new QDBusPendingCallWatcher(pendingCall);
+    connect(watcher, &QDBusPendingCallWatcher::finished, this, [this] (QDBusPendingCallWatcher *watcher) {
+        QDBusPendingReply<QDBusObjectPath> reply = *watcher;
+        if (!reply.isError()) {
+            QDBusConnection::sessionBus().connect(nullptr,
+                                                  reply.value().path(),
+                                                  QStringLiteral("org.freedesktop.portal.Request"),
+                                                  QStringLiteral("Response"),
+                                                  this,
+                                                  SLOT(gotResponse(uint,QVariantMap)));
+        } else {
+            mWarning() << "Failed to open portal file dialog: " << reply.error().message();
+        }
+    });
+#endif
+}
+
+void PortalFileDialog::gotResponse(uint response, const QVariantMap &results)
+{
+    if (!response) {
+        if (results.contains(QLatin1String("uris"))) {
+            const QStringList selectedFiles = results.value(QLatin1String("uris")).toStringList();
+            Q_EMIT fileSelected(selectedFiles.first());
+        }
+    } else {
+        mWarning() << "Portal file dialog cancelled or failed to open";
+    }
+}

--- a/src/app/portalfiledialog.h
+++ b/src/app/portalfiledialog.h
@@ -1,0 +1,73 @@
+/*
+ * Fedora Media Writer
+ * Copyright (C) 2021 Jan Grulich <jgrulich@redhat.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+#ifndef PORTALPortalFileDialog_H
+#define PORTALPortalFileDialog_H
+
+#include <QObject>
+#include <QWindow>
+
+class PortalFileDialog : public QObject
+{
+    Q_OBJECT
+    Q_PROPERTY(bool isAvailable READ isAvailable)
+public:
+    // Copied from QXdgDesktopPortalFileDialog
+    enum ConditionType : uint {
+        GlobalPattern = 0,
+        MimeType = 1
+    };
+    // Filters a(sa(us))
+    // Example: [('Images', [(0, '*.ico'), (1, 'image/png')]), ('Text', [(0, '*.txt')])]
+    struct FilterCondition {
+        ConditionType type;
+        QString pattern; // E.g. '*ico' or 'image/png'
+    };
+    typedef QVector<FilterCondition> FilterConditionList;
+    struct Filter {
+        QString name; // E.g. 'Images' or 'Text
+        FilterConditionList filterConditions;; // E.g. [(0, '*.ico'), (1, 'image/png')] or [(0, '*.txt')]
+    };
+    typedef QVector<Filter> FilterList;
+
+    PortalFileDialog(QObject *parent = nullptr, WId winId = 0);
+    virtual ~PortalFileDialog() override;
+
+    bool isAvailable() const;
+
+public Q_SLOTS:
+    void open();
+
+private Q_SLOTS:
+    void gotResponse(uint response, const QVariantMap &results);
+
+Q_SIGNALS:
+    void fileSelected(const QUrl &fileName);
+
+private:
+    bool m_available;
+    WId m_winId;
+};
+
+Q_DECLARE_METATYPE(PortalFileDialog::FilterCondition);
+Q_DECLARE_METATYPE(PortalFileDialog::FilterConditionList);
+Q_DECLARE_METATYPE(PortalFileDialog::Filter);
+Q_DECLARE_METATYPE(PortalFileDialog::FilterList);
+
+#endif // PORTALPortalFileDialog_H

--- a/src/app/qml/DelegateImage.qml
+++ b/src/app/qml/DelegateImage.qml
@@ -175,7 +175,10 @@ Item {
         function action() {
             if (release.isLocal) {
                 releases.selectedIndex = index
-                fileDialog.visible = true
+                if (portalFileDialog.isAvailable)
+                    portalFileDialog.open()
+                else
+                    fileDialog.open()
             }
             else {
                 imageList.currentIndex = index

--- a/src/app/qml/main.qml
+++ b/src/app/qml/main.qml
@@ -162,6 +162,14 @@ ApplicationWindow {
         }
     }
 
+    Connections {
+        target: portalFileDialog
+        function onFileSelected(fileName) {
+            releases.setLocalFile(fileName)
+            dlDialog.visible = true
+        }
+    }
+
     FullscreenViewer {
         id: fullscreenViewer
     }


### PR DESCRIPTION
There is a bug in QML file dialog [1] causing file dialog freeze in some cases. This should workaround this issue.

Fixes: https://github.com/FedoraQt/MediaWriter/issues/277 and https://github.com/FedoraQt/MediaWriter/issues/339
RH Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1977472

[1] - https://bugreports.qt.io/browse/QTBUG-59184