### PR TITLE
Make version number selectable

### DIFF
--- a/src/app/qml/ImageList.qml
+++ b/src/app/qml/ImageList.qml
@@ -253,11 +253,13 @@ FocusScope {
                             width: parent.width
                             move: Transition { NumberAnimation { properties: "y" } }
 
-                            QQC2.Label {
+                            QQC2.TextArea {
                                 width: parent.width
                                 wrapMode: Text.WrapAtWordBoundaryOrAnywhere
                                 text: qsTr("Version %1").arg(mediawriterVersion)
                                 textFormat: Text.RichText
+                                readOnly: true
+                                selectByMouse: true
                             }
                             QQC2.Label {
                                 width: parent.width


### PR DESCRIPTION
Adds ability to select MediaWriter's version number via the mouse so it
may be copied.