### PR TITLE
Rename 'GNOME 3' to 'GNOME 41'

### DIFF
--- a/po/mediawriter.pot
+++ b/po/mediawriter.pot
@@ -777,7 +777,7 @@ msgstr ""
 #: [Workstation].description[4]
 msgctxt "Release|"
 msgid ""
-"Focus on your code in the GNOME 3 desktop environment. GNOME is built with "
+"Focus on your code in the GNOME 41 desktop environment. GNOME is built with "
 "developer feedback and minimizes distractions, so you can concentrate on "
 "what's important."
 msgstr ""

--- a/src/app/data/assets/metadata.json
+++ b/src/app/data/assets/metadata.json
@@ -16,7 +16,7 @@
             "</em></p></blockquote><h3>",
             "Sleek user interface",
             "</h3><p>",
-            "Focus on your code in the GNOME 3 desktop environment. GNOME is built with developer feedback and minimizes distractions, so you can concentrate on what's important.",
+            "Focus on your code in the GNOME 41 desktop environment. GNOME is built with developer feedback and minimizes distractions, so you can concentrate on what's important.",
             "</p><h3>",
             "Complete open source toolbox",
             "</h3><p>",


### PR DESCRIPTION
Renames "GNOME 3" to "GNOME 41".

Fixes #382 .