### PR TITLE
Update URL for releases.json

### DIFF
--- a/src/app/utilities.h
+++ b/src/app/utilities.h
@@ -83,7 +83,7 @@ public:
 #else
     bool logging{true};
 #endif
-    QString releasesUrl{"https://getfedora.org/releases.json"};
+    QString releasesUrl{"https://fedoraproject.org/releases.json"};
     bool noUserAgent{false}; // disables sending the custom Fedora Media Writer user agent header
 };
 


### PR DESCRIPTION
With the F38 release, getfedora.org is going to be replaced with fedoraproject.org.
The new URL for releases.json will be https://fedoraproject.org/releases.json