### PR TITLE
Recognize Internal SD Card Reader on MacOS

### DIFF
--- a/src/app/macdrivearbiter.mm
+++ b/src/app/macdrivearbiter.mm
@@ -97,7 +97,7 @@ static void OnDiskAppeared(DADiskRef disk, void *__attribute__((__unused__)) ctx
 
         if (isWhole != nil && [isWhole integerValue] != 0) {
             if ((isInternal != nil && [isInternal integerValue] == 0 && isRemovable != nil && [isRemovable integerValue] != 0)
-                || (deviceProtocol != nil && [deviceProtocol isEqual:@"USB"])) {
+                || (deviceProtocol != nil && ([deviceProtocol isEqual:@"USB"] || [deviceProtocol isEqual:@"Secure Digital"]))) {
                     bool isRestoreable = (lastS1 || lastS2)  & [bsdName isEqualToString:lastPrefix];
                     onAdded([bsdName UTF8String], [diskVendor UTF8String], [diskModel UTF8String], [diskSize integerValue], isRestoreable);
             }


### PR DESCRIPTION
Mac Drive Manager only recognized USB connections, this also checks if the drive is an SD connection.

Notice "Connection: USB"
<img width="500" alt="image" src="https://github.com/FedoraQt/MediaWriter/assets/18296791/f8d243f2-edb8-4ea3-b0cd-b852c70e8295">

Notice "Connection: Secure Digital" (which stands for SD, not sure why Apple chose to go with this)
<img width="500" alt="image" src="https://github.com/FedoraQt/MediaWriter/assets/18296791/fb99adc0-1430-480f-8ecb-3a6f4d6b0dc1">

With this Apple's builtin SD card reader works,
<img width="500" alt="image" src="https://github.com/FedoraQt/MediaWriter/assets/18296791/6051b19b-21b6-41cb-b1cb-01c024d38dba">

Note this doesn't affect USB SD Card Readers, because those were always under Connection USB (Same SD card):
<img width="500" alt="image" src="https://github.com/FedoraQt/MediaWriter/assets/18296791/2376fd1c-8636-4f92-9e21-8b76c7e40154">

And for completeness sake, here's the side by side before and after the commit.
<img width="500" alt="image" src="https://github.com/FedoraQt/MediaWriter/assets/18296791/090587ab-f491-4566-a917-411024e40647">

Pretty simple but important change.


