### PR TITLE
Fix restore on Linux with latest UDisks/libblockdev

### DIFF
--- a/src/helper/linux/restorejob.cpp
+++ b/src/helper/linux/restorejob.cpp
@@ -74,7 +74,7 @@ void RestoreJob::work()
     }
 
     QDBusInterface partitionTable("org.freedesktop.UDisks2", where, "org.freedesktop.UDisks2.PartitionTable", QDBusConnection::systemBus(), this);
-    QDBusReply<QDBusObjectPath> partitionReply = partitionTable.call("CreatePartition", 0ULL, device.property("Size").toULongLong(), "", "", Properties());
+    QDBusReply<QDBusObjectPath> partitionReply = partitionTable.call("CreatePartition", 1ULL, 0ULL, "", "", Properties());
     if (!partitionReply.isValid()) {
         err << partitionReply.error().message();
         err.flush();


### PR DESCRIPTION
The newly created partition cannot start on offset 0, previously UDisks was able to compensate for this, but there is a bug in the latest UDisks/libblockdev and this no longer works. But in general offset 0 for a new partition doesn't make sense. We can also use 0 for size to let UDisks calculate the maximal size instead of passing the underlying device size.

Fixes: #644

----

Note that we still plan to fix the UDisks/libblockdev bug, but I think it makes sense to change the values for offset and size here to make the code more future proof -- the 0 offset would never work, so you'd see the udisks warning anyway and having us calculate the max size could avoid some rounding/alignment issues in the future.