### PR TITLE
Updating emerging editions to Atomic Desktop

### DIFF
--- a/src/app/data/assets/metadata.json
+++ b/src/app/data/assets/metadata.json
@@ -143,22 +143,22 @@
     {
         "subvariant": "onyx",
         "category": "emerging",
-        "name": "Fedora Onyx",
-        "summary": "Fedora Onyx",
+        "name": "Fedora Budgie Atomic",
+        "summary": "Fedora Budgie Atomic",
         "description": [
             "<p>",
-            "Fedora Onyx",
+            "Fedora Budgie Atomic",
             "</p>"
         ]
     },
     {
         "subvariant": "sericea",
         "category": "emerging",
-        "name": "Fedora Sericea",
-        "summary": "Fedora Sericea",
+        "name": "Fedora Sway Atomic",
+        "summary": "Fedora Sway Atomic",
         "description": [
             "<p>",
-            "Fedora Sericea",
+            "Fedora Sway Atomic",
             "</p>"
         ]
     },

--- a/src/app/qml/VersionPage.qml
+++ b/src/app/qml/VersionPage.qml
@@ -26,53 +26,53 @@ import QtQml 6.2
 Page {
     id: versionPage
     property int prevSource: 0
-    
+
     ColumnLayout {
         anchors.fill: parent
-        
+
         Heading {
             Layout.alignment: Qt.AlignHCenter
             text: qsTr("Select Fedora Release")
             level: 5
         }
-        
+
         ButtonGroup {
             id: radioGroup
         }
-        
+
         ColumnLayout {
             id: radioColumn
             Layout.alignment: Qt.AlignTop
-            
+
             Label {
                 text: qsTr("Select from:")
             }
-        
+
             RadioButton {
                 checked: true
                 text: qsTr("Official Editions")
                 onClicked: changeFilter(Units.Source.Product)
                 ButtonGroup.group: radioGroup
             }
-    
+
             RadioButton {
-                text: qsTr("Emerging Editions")
+                text: qsTr("Atomic Desktops")
                 onClicked: changeFilter(Units.Source.Emerging)
                 ButtonGroup.group: radioGroup
             }
-            
+
             RadioButton {
                 text: qsTr("Spins")
                 onClicked: changeFilter(Units.Source.Spins)
                 ButtonGroup.group: radioGroup
             }
-            
+
             RadioButton {
                 text: qsTr("Labs")
                 onClicked: changeFilter(Units.Source.Labs)
                 ButtonGroup.group: radioGroup
             }
-        
+
             ComboBox {
                 id: selectFromComboBox
                 Layout.alignment: Qt.AlignHCenter
@@ -86,7 +86,7 @@ Page {
             }
         }
     }
-    
+
     function changeFilter(filter) {
         releases.filterSource = filter
         if (releases.filterSource != prevSource) {

--- a/src/app/releasemanager.cpp
+++ b/src/app/releasemanager.cpp
@@ -429,7 +429,7 @@ QString Release::sourceString()
     case LABS:
         return tr("Fedora Labs");
     case EMERGING:
-        return tr("Emerging Fedora Editions");
+        return tr("Fedora Atomic Desktops");
     default:
         return tr("Other");
     }


### PR DESCRIPTION
Changed the text descriptions for the new Atomic Desktop branding.

See: https://fedoramagazine.org/introducing-fedora-atomic-desktops/

Closes: #684