### PR TITLE
chore: specify UAC level to `requireAdministrator` in the manifest for Windows

### DIFF
--- a/src/app/CMakeLists.txt
+++ b/src/app/CMakeLists.txt
@@ -41,7 +41,16 @@ if (NOT APPLE)
 endif()
 
 if (WIN32)
-    set_target_properties(mediawriter PROPERTIES WIN32_EXECUTABLE TRUE)
+    # NOTE: QProcess::start() can not start a new process with UAC level
+    # requireAdministrator, since it is using CreateProcess. There is one
+    # API that can trigger the UAC prompt, ShellExecute or ShellExecuteEx,
+    # but process started by them can not be managed by QProcess.
+    # There are some workarounds but since the QProcess instance is connected
+    # to various slots, it would require a rewrite to apply the workarounds.
+    # We simply specify the main app to require administrator privilege in
+    # the manifest.
+    set_target_properties(mediawriter PROPERTIES WIN32_EXECUTABLE TRUE
+        LINK_FLAGS "/MANIFESTUAC:\"level='requireAdministrator' uiAccess='false'\"")
 endif()
 
 if (WIN32)

--- a/src/helper/win/CMakeLists.txt
+++ b/src/helper/win/CMakeLists.txt
@@ -29,6 +29,10 @@ target_link_libraries(helper
     ${LIBLZMA_LIBRARIES}
 )
 
-set_target_properties(helper PROPERTIES RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/src/app)
+# Specify the UAC level to requireAdministrator in the manifest, in order
+# to trigger a UAC prompt upon launch.
+set_target_properties(helper PROPERTIES
+    RUNTIME_OUTPUT_DIRECTORY ${CMAKE_BINARY_DIR}/src/app
+    LINK_FLAGS "/MANIFESTUAC:\"level='requireAdministrator' uiAccess='false'\"")
 
 install(TARGETS helper DESTINATION ${CMAKE_INSTALL_FULL_LIBEXECDIR}/mediawriter)


### PR DESCRIPTION
By specifying the UAC level in the manifest, the program will trigger a UAC prompt upon launch. Thus the helper will launch with administrator privileges:

![image](https://github.com/FedoraQt/MediaWriter/assets/29174191/77357204-e709-4bcf-ae10-fbb5fc2e806f)

We initially added the UAC level to the helper, however the way how `helper.exe` is launched does not allow the UAC prompt to pop up[^1]. Using alternative APIs can resolve this, but it would require a rewrite to apply the workaround, namely `QProcess::startDetached()`, which launches a new process that can not be managed by `QProcess`.

[^1]: https://learn.microsoft.com/en-us/windows/win32/dxtecharts/user-account-control-for-game-developers?redirectedfrom=MSDN#uac-implications-with-createprocess