### PR TITLE
Fixes for po/build-translations.sh

### DIFF
--- a/po/build-translations.sh
+++ b/po/build-translations.sh
@@ -7,6 +7,9 @@ echo -e '<RCC>\n\t<qresource prefix="/translations/">' > ../src/translations/tra
 for i in `ls mediawriter_*.po`; do
     echo $i
     LANGCODE=$(sed 's/mediawriter_\([^.]*\).po/\1/' <<< "$i")
+    if [[ "$LANGCODE" = "pt-BR" || "$LANGCODE" = "zh-CN" || "$LANGCODE" = "zh-TW" ]]; then
+        LANGCODE=${LANGCODE/-/_}
+    fi
     lrelease-qt5 $i -qm ../src/translations/$LANGCODE.qm
     echo -e "\t\t<file>${LANGCODE}.qm</file>" >> ../src/translations/translations.qrc
 done

--- a/po/build-translations.sh
+++ b/po/build-translations.sh
@@ -3,16 +3,14 @@
 ####### App translations
 rm -f *.qm
 
-echo -e '<RCC>' > translations.qrc
-echo -e '\t<qresource prefix="/translations/">' >> translations.qrc
+echo -e '<RCC>\n\t<qresource prefix="/translations/">' > ../src/translations/translations.qrc
 for i in `ls mediawriter_*.po`; do
     echo $i
     LANGCODE=$(sed 's/mediawriter_\([^.]*\).po/\1/' <<< "$i")
-    lrelease-qt5 $i -qm $LANGCODE.qm
-    echo -e "\t\t<file>${LANGCODE}.qm</file>" >> translations.qrc
+    lrelease-qt5 $i -qm ../src/translations/$LANGCODE.qm
+    echo -e "\t\t<file>${LANGCODE}.qm</file>" >> ../src/translations/translations.qrc
 done
-echo -e '\t</qresource>' >> translations.qrc
-echo -e '</RCC>' >> translations.qrc
+echo -e '\t</qresource>\n</RCC>' >> ../src/translations/translations.qrc
 
 ####### Appstream metadata
 for i in `ls mediawriter_*.po`; do


### PR DESCRIPTION
This pull request contains two scripting errors in `po/build-translations` that should hopefully make the (currently manual) Qt translation generation procedures simpler:

- Output `*.qm` and `*.qrc` directly to `/src/translations`.
- Automatically convert `pt-BR`, `zh-CN`, and `zh-TW` language tags to `pt_BR`, `zh_CN`, and `zh_TW`.