### PR TITLE
fix(qml/DownloadPage): fix download remaining size display

### DIFF
--- a/src/app/qml/DownloadPage.qml
+++ b/src/app/qml/DownloadPage.qml
@@ -107,7 +107,6 @@ Page {
 
                 Label {
                     visible: currentStatus == Units.DownloadStatus.Downloading
-                    Layout.preferredWidth: fontMetrics.width
                     text: progressColumn.leftStr
                 }
 


### PR DESCRIPTION
The original code incorrectly (and unnecessarily?) calculates the width of the string before the displayed unit, causing the size number and unit to overlap.

Dropping this line fixes this issue.