### PR TITLE
Update README.md, removing `adwaita-qt` as requirement

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,6 @@ The main binary, `mediawriter`, will be written to `$PREFIX/bin` and the helper 
 
 #### Requirements
 
-* `adwaita-qt`
 * `udisks2` or `storaged`
 * `xz-libs`
 


### PR DESCRIPTION
Removing `adwaita-qt` as one of the requirements for Linux, per [discussion here](https://github.com/FedoraQt/MediaWriter/issues/706#event-12347448404).