### PR TITLE
Fix overfloating heading for longer texts

### DIFF
--- a/src/app/qml/Page.qml
+++ b/src/app/qml/Page.qml
@@ -72,8 +72,13 @@ QQC2.Page {
         Heading {
             id: heading
             Layout.alignment: Qt.AlignHCenter | Qt.AlignTop
+            Layout.preferredWidth: mainLayout.width
+            horizontalAlignment: Text.AlignHCenter
+            elide: Text.ElideRight
             level: 5
+            maximumLineCount: 2
             visible: text
+            wrapMode:Text.WordWrap
         }
 
         ColumnLayout {


### PR DESCRIPTION
Wrap the heading in case of a longer text and elide it to the right side in case the number of lines exceeds two lines (won't probably happen).