### PR TITLE
Fix language detection

### DIFF
--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -51,7 +51,7 @@ int main(int argc, char **argv)
     mDebug() << "Application constructed";
 
     QTranslator translator;
-    if (translator.load(QLocale(), QLatin1String(), QLatin1String(), ":/translations"))
+    if (translator.load(QLocale(QLocale::system().language()), QLatin1String(), QLatin1String(), ":/translations"))
         app.installTranslator(&translator);
 
     QGuiApplication::setDesktopFileName("org.fedoraproject.MediaWriter.desktop");


### PR DESCRIPTION
Using QLocale::system() gives the correct locale, but uiLanguages() can give us language we don't want to. Instead just construct a new QLocale with the language reported as primary by QLocale::system().

Fixes #271