### PR TITLE
Install Fedora Media Writer to 'C:\Program Files' on Windows x64

### DIFF
--- a/dist/win/mediawriter.nsi
+++ b/dist/win/mediawriter.nsi
@@ -60,7 +60,7 @@ Var UninstLog
 
 RequestExecutionLevel admin ;Require admin rights on NT6+ (When UAC is turned on)
 
-InstallDir "$PROGRAMFILES\${APPNAME}"
+InstallDir "$PROGRAMFILES64\${APPNAME}"
 
 # rtf or txt file - remember if it is txt, it must be in the DOS text format (\r\n)
 LicenseData "../../build/app/release/LICENSE.GPL-2.txt"

--- a/dist/win/mediawriter_native.nsi
+++ b/dist/win/mediawriter_native.nsi
@@ -60,7 +60,7 @@ Var UninstLog
 
 RequestExecutionLevel admin ;Require admin rights on NT6+ (When UAC is turned on)
 
-InstallDir "$PROGRAMFILES\${APPNAME}"
+InstallDir "$PROGRAMFILES64\${APPNAME}"
 
 # rtf or txt file - remember if it is txt, it must be in the DOS text format (\r\n)
 LicenseData "../../build/app/release/LICENSE.GPL-2.txt"


### PR DESCRIPTION
Quoting NSIS's [Reference/$PROGRAMFILES](https://nsis.sourceforge.io/Reference/$PROGRAMFILES) doc:
> The program files directory (usually `C:\Program Files` but detected at runtime). On Windows x64, `$PROGRAMFILES` and `$PROGRAMFILES32` point to `C:\Program Files (x86)` while `$PROGRAMFILES64` points to `C:\Program Files`. Use `$PROGRAMFILES64` when installing x64 applications.

Fixes #791 