### PR TITLE
Properly set desktop file name

### DIFF
--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -57,7 +57,7 @@ int main(int argc, char **argv)
         app.installTranslator(&translator);
     }
 
-    QGuiApplication::setDesktopFileName("org.fedoraproject.MediaWriter.desktop");
+    QGuiApplication::setDesktopFileName("org.fedoraproject.MediaWriter");
 
     mDebug() << "Injecting QML context properties";
     QQmlApplicationEngine engine;


### PR DESCRIPTION
QGuiApplication::SetDesktopFileName() expects the name to be without the ".desktop" suffix