### PR TITLE
Do not warn about unsupported architectures

### DIFF
--- a/src/app/releasemanager.cpp
+++ b/src/app/releasemanager.cpp
@@ -190,7 +190,7 @@ bool ReleaseManager::updateUrl(const QString &release,
                                int64_t size)
 {
     if (!ReleaseArchitecture::isKnown(architecture)) {
-        mWarning() << "Architecture" << architecture << "is not known!";
+        mDebug() << "Architecture" << architecture << "is not known!";
         return false;
     }
     for (int i = 0; i < m_sourceModel->rowCount(); i++) {


### PR DESCRIPTION
This warning message is useless, instead put it into a debug.