### PR TITLE
Add translation URL to appdata file

### DIFF
--- a/src/app/data/org.fedoraproject.MediaWriter.appdata.xml.in
+++ b/src/app/data/org.fedoraproject.MediaWriter.appdata.xml.in
@@ -23,6 +23,7 @@
         <keyword>media</keyword>
     </keywords>
 	<url type="homepage">https://github.com/FedoraQt/MediaWriter</url>
+        <url type="translate">https://translate.fedoraproject.org/engage/fedora-media-writer</url>
 	<screenshots>
 	<screenshot type="default"><image type="source">https://github.com/FedoraQt/MediaWriter/raw/main/dist/screenshots/linux_main.png</image></screenshot>
 	    <screenshot><image type="source">https://github.com/FedoraQt/MediaWriter/raw/main/dist/screenshots/linux_select_release.png</image></screenshot>


### PR DESCRIPTION
This URL is used by app stores like Flathub, GNOME Software and KDE Discover to show hownto contribute with translations.

Question: should I also change `src/app/data/org.fedoraproject.MediaWriter.appdata.xml` or is it automatically generated somehow?