### PR TITLE
fix(windows): restore application icon resource

### DIFF
--- a/src/app/CMakeLists.txt
+++ b/src/app/CMakeLists.txt
@@ -54,7 +54,7 @@ if (WIN32)
     # HACK: we need to remove -std=c++11 definition for manifest file, otherwise
     # it will complain about undefined option "s" (as first letter from -Std=c++11)
     remove_definitions(-std=c++11)
-    # target_sources(mediawriter PRIVATE data/windows.rc)
+    target_sources(mediawriter PRIVATE data/windows.rc)
 endif()
 
 if (APPLE)

--- a/src/app/data/windows.rc
+++ b/src/app/data/windows.rc
@@ -1,4 +1,3 @@
 #include "winuser.h"
 
-CREATEPROCESS_MANIFEST_RESOURCE_ID RT_MANIFEST "windows.manifest"
 IDI_ICON1 ICON "icons/mediawriter.ico"


### PR DESCRIPTION
## Summary

The Windows build currently does not embed the application icon resource.

As a result, the executable and window can miss the expected Fedora Media Writer icon.

## Change

Re-enable `windows.rc` in the Windows build and keep it limited to the icon resource.

The manifest entry is removed from `windows.rc` because the build already sets the Windows manifest through linker flags, and keeping both results in a duplicate manifest resource during linking.

## Validation

Built the project locally on Windows and verified that the application icon is embedded again and shown in the title bar.

## Before

![Before](https://github.com/user-attachments/assets/4262c19c-078b-4e96-9559-b9d6f52a445b)
## After

![After](https://github.com/user-attachments/assets/78ef9c75-c1ed-40e6-b07b-23a2d7bde684)

## Risk

Low.

This change only restores the Windows icon resource and avoids the duplicate manifest conflict during linking.
