### PR TITLE
fix(qml): escape ampersand in start button

### DIFF
--- a/src/app/qml/DeviceWarningDialog.qml
+++ b/src/app/qml/DeviceWarningDialog.qml
@@ -71,9 +71,7 @@ ModalDialog {
                     const variant = releases.selected && releases.selected.version ? releases.selected.version.variant : null
                     if (selectedOption === Units.MainSelect.Write || (variant && downloadManager.isDownloaded(variant.url)))
                         return qsTr("Write")
-                    if (Qt.platform.os === "windows" || Qt.platform.os === "osx")
-                        return qsTr("Download && Write")
-                    return qsTr("Download & Write")
+                    return qsTr("Download && Write")
                 }
             }
         }

--- a/src/app/qml/DrivePage.qml
+++ b/src/app/qml/DrivePage.qml
@@ -158,9 +158,7 @@ Page {
     nextButtonText: {
         if (selectedOption == Units.MainSelect.Write || downloadManager.isDownloaded(releases.selected.version.variant.url))
             return qsTr("Write")
-        if (Qt.platform.os === "windows" || Qt.platform.os === "osx")
-            return qsTr("Download && Write")
-        return qsTr("Download & Write")
+        return qsTr("Download && Write")
     }
 
     onPreviousButtonClicked: {


### PR DESCRIPTION
fix(qml): escape ampersand in start button

No separate conditions needed.

Tested on Fedora Workstation 44 installation.

Fixes #901 

<img width="1000" height="1088" alt="image" src="https://github.com/user-attachments/assets/e59c8b86-6f1b-47a4-b2ee-bed1f1f8add1" />

<img width="662" height="540" alt="image" src="https://github.com/user-attachments/assets/1a916383-e835-47a4-af3c-a50c41d5a084" />
