### PR TITLE
fix(qml): show only download on zero drives

### DIFF
--- a/src/app/qml/DeviceWarningDialog.qml
+++ b/src/app/qml/DeviceWarningDialog.qml
@@ -71,9 +71,7 @@ ModalDialog {
                     const variant = releases.selected && releases.selected.version ? releases.selected.version.variant : null
                     if (selectedOption === Units.MainSelect.Write || (variant && downloadManager.isDownloaded(variant.url)))
                         return qsTr("Write")
-                    if (Qt.platform.os === "windows" || Qt.platform.os === "osx")
-                        return qsTr("Download && Write")
-                    return qsTr("Download & Write")
+                    return qsTr("Download && Write")
                 }
             }
         }

--- a/src/app/qml/DeviceWarningDialog.qml
+++ b/src/app/qml/DeviceWarningDialog.qml
@@ -71,6 +71,8 @@ ModalDialog {
                     const variant = releases.selected && releases.selected.version ? releases.selected.version.variant : null
                     if (selectedOption === Units.MainSelect.Write || (variant && downloadManager.isDownloaded(variant.url)))
                         return qsTr("Write")
+                    if (!drives.length)
+                        return qsTr("Download")
                     return qsTr("Download && Write")
                 }
             }

--- a/src/app/qml/DrivePage.qml
+++ b/src/app/qml/DrivePage.qml
@@ -158,9 +158,7 @@ Page {
     nextButtonText: {
         if (selectedOption == Units.MainSelect.Write || downloadManager.isDownloaded(releases.selected.version.variant.url))
             return qsTr("Write")
-        if (Qt.platform.os === "windows" || Qt.platform.os === "osx")
-            return qsTr("Download && Write")
-        return qsTr("Download & Write")
+        return qsTr("Download && Write")
     }
 
     onPreviousButtonClicked: {

--- a/src/app/qml/DrivePage.qml
+++ b/src/app/qml/DrivePage.qml
@@ -158,6 +158,8 @@ Page {
     nextButtonText: {
         if (selectedOption == Units.MainSelect.Write || downloadManager.isDownloaded(releases.selected.version.variant.url))
             return qsTr("Write")
+        if (!drives.length)
+            return qsTr("Download")
         return qsTr("Download && Write")
     }
 


### PR DESCRIPTION
fix(qml): show only download on zero drives

Fixes #862 (Depends #978)

Should we not simply disable the button when a USB drive is not connected?

I am not certain about the usecases needing fetching and writing separately.

- For when we have zero drives with locally available files
  <img width="662" height="540" alt="image" src="https://github.com/user-attachments/assets/cf6a3e59-43e9-4708-8c01-f8b8ec108387" />

- For when we have one (or more) drives without locally available files
  <img width="662" height="540" alt="image" src="https://github.com/user-attachments/assets/bbfacbd1-04d9-4916-9067-282ad778a90d" />

- For when we have one (or more) drives with locally available files
  <img width="662" height="540" alt="image" src="https://github.com/user-attachments/assets/90d61415-38e0-4ef3-8b36-5db0b67c435f" />
