### PR TITLE
fix(cpp): enable keyboard focus navigation on all interactive controls

### DIFF
--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -21,6 +21,7 @@
 #include <QApplication>
 #include <QQmlApplicationEngine>
 #include <QQmlContext>
+#include <QStyleHints>
 #include <QTranslator>
 
 #include "crashhandler.h"
@@ -46,6 +47,7 @@ int main(int argc, char **argv)
     QApplication::setApplicationName("MediaWriter");
 
     QApplication app(argc, argv);
+    app.styleHints()->setTabFocusBehavior(Qt::TabFocusAllControls);
     const int parseResult = options.parse(app.arguments());
     if (parseResult >= 0) {
         return parseResult;


### PR DESCRIPTION
fix(cpp): enable keyboard focus navigation on all interactive controls

Fixes #619

Build the project locally and use `Tab`/`Shift`+`Tab` to test.

Wish there was a way to avoid repetitions...