### PR TITLE
feat(qml,cpp): introduce visible mnemonics for accessible navigation

### DIFF
--- a/src/app/CMakeLists.txt
+++ b/src/app/CMakeLists.txt
@@ -8,6 +8,7 @@ set(MEDIAWRITER_SRCS
     downloadmanager.cpp
     drivemanager.cpp
     main.cpp
+    mnemonicfilter.cpp
     notifications.cpp
     portalfiledialog.cpp
     releasemanager.cpp

--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -26,6 +26,7 @@
 
 #include "crashhandler.h"
 #include "drivemanager.h"
+#include "mnemonicfilter.h"
 #include "portalfiledialog.h"
 #include "releasemanager.h"
 
@@ -67,8 +68,12 @@ int main(int argc, char **argv)
     mDebug() << "Injecting QML context properties";
     QQmlApplicationEngine engine;
 
+    auto *mnemonicFilter = new MnemonicFilter(&app);
+    app.installEventFilter(mnemonicFilter);
+
     engine.rootContext()->setContextProperty("downloadManager", DownloadManager::instance());
     engine.rootContext()->setContextProperty("drives", DriveManager::instance());
+    engine.rootContext()->setContextProperty("mnemonicFilter", mnemonicFilter);
     engine.rootContext()->setContextProperty("portalFileDialog", new PortalFileDialog(&app));
     engine.rootContext()->setContextProperty("mediawriterVersion", MEDIAWRITER_VERSION);
     engine.rootContext()->setContextProperty("releases", new ReleaseManager());

--- a/src/app/mnemonicfilter.cpp
+++ b/src/app/mnemonicfilter.cpp
@@ -1,0 +1,51 @@
+/*
+ * Fedora Media Writer
+ * Copyright (C) 2024 Jan Grulich <jgrulich@redhat.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+#include "mnemonicfilter.h"
+
+#include <QKeyEvent>
+
+MnemonicFilter::MnemonicFilter(QObject *parent)
+    : QObject(parent)
+{
+}
+
+bool MnemonicFilter::altPressed() const
+{
+    return m_altPressed;
+}
+
+bool MnemonicFilter::eventFilter(QObject *obj, QEvent *event)
+{
+    if (event->type() == QEvent::KeyPress) {
+        auto *keyEvent = static_cast<QKeyEvent *>(event);
+        if (keyEvent->key() == Qt::Key_Alt && !m_altPressed) {
+            m_altPressed = true;
+            emit altPressedChanged();
+        }
+    } else if (event->type() == QEvent::KeyRelease) {
+        auto *keyEvent = static_cast<QKeyEvent *>(event);
+        if (keyEvent->key() == Qt::Key_Alt && m_altPressed) {
+            m_altPressed = false;
+            emit altPressedChanged();
+        }
+    }
+
+    return QObject::eventFilter(obj, event);
+}

--- a/src/app/mnemonicfilter.h
+++ b/src/app/mnemonicfilter.h
@@ -1,0 +1,45 @@
+/*
+ * Fedora Media Writer
+ * Copyright (C) 2024 Jan Grulich <jgrulich@redhat.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+#ifndef MNEMONICFILTER_H
+#define MNEMONICFILTER_H
+
+#include <QObject>
+
+class MnemonicFilter : public QObject
+{
+    Q_OBJECT
+    Q_PROPERTY(bool altPressed READ altPressed NOTIFY altPressedChanged)
+
+public:
+    explicit MnemonicFilter(QObject *parent = nullptr);
+
+    bool altPressed() const;
+
+signals:
+    void altPressedChanged();
+
+protected:
+    bool eventFilter(QObject *obj, QEvent *event) override;
+
+private:
+    bool m_altPressed = false;
+};
+
+#endif // MNEMONICFILTER_H

--- a/src/app/qml.qrc
+++ b/src/app/qml.qrc
@@ -7,6 +7,9 @@
         <file>qml/DrivePage.qml</file>
         <file>qml/Heading.qml</file>
         <file>qml/MainPage.qml</file>
+        <file>qml/MnemonicButton.qml</file>
+        <file>qml/MnemonicCheckBox.qml</file>
+        <file>qml/MnemonicRadioButton.qml</file>
         <file>qml/ModalDialog.qml</file>
         <file>qml/Page.qml</file>
         <file>qml/RestorePage.qml</file>

--- a/src/app/qml.qrc
+++ b/src/app/qml.qrc
@@ -8,6 +8,7 @@
         <file>qml/Heading.qml</file>
         <file>qml/MainPage.qml</file>
         <file>qml/MnemonicButton.qml</file>
+        <file>qml/MnemonicHandler.qml</file>
         <file>qml/MnemonicCheckBox.qml</file>
         <file>qml/MnemonicRadioButton.qml</file>
         <file>qml/ModalDialog.qml</file>

--- a/src/app/qml/AboutDialog.qml
+++ b/src/app/qml/AboutDialog.qml
@@ -80,7 +80,7 @@ ModalDialog {
 
             MnemonicButton {
                 id: closeButton
-                mnemonicText: qsTr("<u>C</u>lose")
+                mnemonicText: qsTr("&Close")
                 shortcutActive: aboutDialog.visible
                 onClicked: aboutDialog.close()
             }

--- a/src/app/qml/AboutDialog.qml
+++ b/src/app/qml/AboutDialog.qml
@@ -78,10 +78,11 @@ ModalDialog {
                 Layout.fillWidth: true
             }
 
-            QQC2.Button {
+            MnemonicButton {
                 id: closeButton
+                mnemonicText: qsTr("<u>C</u>lose")
+                shortcutActive: aboutDialog.visible
                 onClicked: aboutDialog.close()
-                text: qsTr("Close")
             }
         }
     }

--- a/src/app/qml/CancelDialog.qml
+++ b/src/app/qml/CancelDialog.qml
@@ -76,7 +76,7 @@ ModalDialog {
 
             MnemonicButton {
                 id: continueButton
-                mnemonicText: qsTr("C<u>o</u>ntinue")
+                mnemonicText: qsTr("C&ontinue")
                 shortcutActive: cancelDialog.visible
                 onClicked: cancelDialog.close()
             }
@@ -100,13 +100,13 @@ ModalDialog {
                 }
                 mnemonicText: {
                     if (variantStatus === Units.DownloadStatus.Downloading || variantStatus === Units.DownloadStatus.Download_Verifying)
-                        qsTr("Cancel <u>D</u>ownload")
+                        qsTr("Cancel &Download")
                     else if (variantStatus === Units.DownloadStatus.Writing)
-                        qsTr("Cancel <u>W</u>riting")
+                        qsTr("Cancel &Writing")
                     else if (variantStatus === Units.DownloadStatus.Write_Verifying)
-                        qsTr("Cancel <u>V</u>erification")
+                        qsTr("Cancel &Verification")
                     else
-                        qsTr("<u>C</u>ancel")
+                        qsTr("&Cancel")
                 }
             }
         }

--- a/src/app/qml/CancelDialog.qml
+++ b/src/app/qml/CancelDialog.qml
@@ -74,14 +74,16 @@ ModalDialog {
                 Layout.fillWidth: true
             }
 
-            QQC2.Button {
+            MnemonicButton {
                 id: continueButton
+                mnemonicText: qsTr("C<u>o</u>ntinue")
+                shortcutActive: cancelDialog.visible
                 onClicked: cancelDialog.close()
-                text: qsTr("Continue")
             }
 
-            QQC2.Button {
+            MnemonicButton {
                 id: cancelButton
+                shortcutActive: cancelDialog.visible
                 onClicked: {
                     cancelDialog.close()
                     // Store release state locally as drives.selected.cancel() makes
@@ -96,15 +98,15 @@ ModalDialog {
                     downloadManager.cancel()
                     selectedPage = Units.Page.MainPage
                 }
-                text: {
+                mnemonicText: {
                     if (variantStatus === Units.DownloadStatus.Downloading || variantStatus === Units.DownloadStatus.Download_Verifying)
-                        qsTr("Cancel Download")
+                        qsTr("Cancel <u>D</u>ownload")
                     else if (variantStatus === Units.DownloadStatus.Writing)
-                        qsTr("Cancel Writing")
+                        qsTr("Cancel <u>W</u>riting")
                     else if (variantStatus === Units.DownloadStatus.Write_Verifying)
-                        qsTr("Cancel Verification")
+                        qsTr("Cancel <u>V</u>erification")
                     else
-                        qsTr("Cancel")
+                        qsTr("<u>C</u>ancel")
                 }
             }
         }

--- a/src/app/qml/DeviceWarningDialog.qml
+++ b/src/app/qml/DeviceWarningDialog.qml
@@ -51,14 +51,16 @@ ModalDialog {
                 Layout.fillWidth: true
             }
 
-            QQC2.Button {
+            MnemonicButton {
                 id: cancelButton
+                mnemonicText: qsTr("<u>C</u>ancel")
+                shortcutActive: deviceWarningDialog.visible
                 onClicked: deviceWarningDialog.close()
-                text: qsTr("Cancel")
             }
 
-            QQC2.Button {
+            MnemonicButton {
                 id: continueButton
+                shortcutActive: deviceWarningDialog.visible
                 onClicked: {
                     deviceWarningDialog.close()
                     selectedPage = Units.Page.DownloadPage
@@ -67,13 +69,13 @@ ModalDialog {
                         drives.selected.write(releases.variant)
                     }
                 }
-                text: {
+                mnemonicText: {
                     const variant = releases.selected && releases.selected.version ? releases.selected.version.variant : null
                     if (selectedOption === Units.MainSelect.Write || (variant && downloadManager.isDownloaded(variant.url)))
-                        return qsTr("Write")
+                        return qsTr("<u>W</u>rite")
                     if (!drives.length)
-                        return qsTr("Download")
-                    return qsTr("Download && Write")
+                        return qsTr("<u>D</u>ownload")
+                    return qsTr("<u>D</u>ownload && Write")
                 }
             }
         }

--- a/src/app/qml/DeviceWarningDialog.qml
+++ b/src/app/qml/DeviceWarningDialog.qml
@@ -53,7 +53,7 @@ ModalDialog {
 
             MnemonicButton {
                 id: cancelButton
-                mnemonicText: qsTr("<u>C</u>ancel")
+                mnemonicText: qsTr("&Cancel")
                 shortcutActive: deviceWarningDialog.visible
                 onClicked: deviceWarningDialog.close()
             }
@@ -72,10 +72,10 @@ ModalDialog {
                 mnemonicText: {
                     const variant = releases.selected && releases.selected.version ? releases.selected.version.variant : null
                     if (selectedOption === Units.MainSelect.Write || (variant && downloadManager.isDownloaded(variant.url)))
-                        return qsTr("<u>W</u>rite")
+                        return qsTr("&Write")
                     if (!drives.length)
-                        return qsTr("<u>D</u>ownload")
-                    return qsTr("<u>D</u>ownload && Write")
+                        return qsTr("&Download")
+                    return qsTr("&Download && Write")
                 }
             }
         }

--- a/src/app/qml/DownloadPage.qml
+++ b/src/app/qml/DownloadPage.qml
@@ -232,7 +232,7 @@ Page {
     // There will be only [Finish] button on the right side so [Cancel] button
     // is not necessary
     previousButtonVisible: currentStatus != Units.DownloadStatus.Finished
-    previousButtonText: qsTr("Cancel")
+    previousButtonText: qsTr("<u>C</u>ancel")
     onPreviousButtonClicked: {
         if (releases.variant.status === Units.DownloadStatus.Write_Verifying ||
             releases.variant.status === Units.DownloadStatus.Writing ||
@@ -259,11 +259,11 @@ Page {
     }
     nextButtonText: {
         if (currentStatus === Units.DownloadStatus.Ready)
-            return qsTr("Write")
+            return qsTr("<u>W</u>rite")
         else if (currentStatus === Units.DownloadStatus.Finished)
-            return qsTr("Finish")
+            return qsTr("<u>F</u>inish")
         else
-            return qsTr("Retry")
+            return qsTr("<u>R</u>etry")
     }
     onNextButtonClicked: {
         if (currentStatus === Units.DownloadStatus.Finished) {

--- a/src/app/qml/DownloadPage.qml
+++ b/src/app/qml/DownloadPage.qml
@@ -232,7 +232,7 @@ Page {
     // There will be only [Finish] button on the right side so [Cancel] button
     // is not necessary
     previousButtonVisible: currentStatus != Units.DownloadStatus.Finished
-    previousButtonText: qsTr("<u>C</u>ancel")
+    previousButtonText: qsTr("&Cancel")
     onPreviousButtonClicked: {
         if (releases.variant.status === Units.DownloadStatus.Write_Verifying ||
             releases.variant.status === Units.DownloadStatus.Writing ||
@@ -259,11 +259,11 @@ Page {
     }
     nextButtonText: {
         if (currentStatus === Units.DownloadStatus.Ready)
-            return qsTr("<u>W</u>rite")
+            return qsTr("&Write")
         else if (currentStatus === Units.DownloadStatus.Finished)
-            return qsTr("<u>F</u>inish")
+            return qsTr("&Finish")
         else
-            return qsTr("<u>R</u>etry")
+            return qsTr("&Retry")
     }
     onNextButtonClicked: {
         if (currentStatus === Units.DownloadStatus.Finished) {

--- a/src/app/qml/DrivePage.qml
+++ b/src/app/qml/DrivePage.qml
@@ -85,10 +85,10 @@ Page {
                 elide: QQC2.Label.ElideRight
             }
 
-            QQC2.Button {
+            MnemonicButton {
                 id: selectFileButton
                 Layout.alignment: Qt.AlignRight
-                text: qsTr("Select...")
+                mnemonicText: qsTr("<u>S</u>elect...")
                 onClicked: {
                     if (portalFileDialog.isAvailable)
                         portalFileDialog.open()
@@ -147,8 +147,9 @@ Page {
             level: 1
         }
 
-        QQC2.CheckBox {
-            text: qsTr("Delete download after writing")
+        MnemonicCheckBox {
+            id: deleteDownloadCheckBox
+            mnemonicText: qsTr("De<u>l</u>ete download after writing")
             onCheckedChanged: mainWindow.eraseVariant = !mainWindow.eraseVariant
         }
     }
@@ -157,10 +158,10 @@ Page {
 
     nextButtonText: {
         if (selectedOption == Units.MainSelect.Write || downloadManager.isDownloaded(releases.selected.version.variant.url))
-            return qsTr("Write")
+            return qsTr("<u>W</u>rite")
         if (!drives.length)
-            return qsTr("Download")
-        return qsTr("Download && Write")
+            return qsTr("<u>D</u>ownload")
+        return qsTr("<u>D</u>ownload && Write")
     }
 
     onPreviousButtonClicked: {

--- a/src/app/qml/DrivePage.qml
+++ b/src/app/qml/DrivePage.qml
@@ -88,7 +88,7 @@ Page {
             MnemonicButton {
                 id: selectFileButton
                 Layout.alignment: Qt.AlignRight
-                mnemonicText: qsTr("<u>S</u>elect...")
+                mnemonicText: qsTr("&Select...")
                 onClicked: {
                     if (portalFileDialog.isAvailable)
                         portalFileDialog.open()
@@ -149,7 +149,7 @@ Page {
 
         MnemonicCheckBox {
             id: deleteDownloadCheckBox
-            mnemonicText: qsTr("De<u>l</u>ete download after writing")
+            mnemonicText: qsTr("De&lete download after writing")
             onCheckedChanged: mainWindow.eraseVariant = !mainWindow.eraseVariant
         }
     }
@@ -158,10 +158,10 @@ Page {
 
     nextButtonText: {
         if (selectedOption == Units.MainSelect.Write || downloadManager.isDownloaded(releases.selected.version.variant.url))
-            return qsTr("<u>W</u>rite")
+            return qsTr("&Write")
         if (!drives.length)
-            return qsTr("<u>D</u>ownload")
-        return qsTr("<u>D</u>ownload && Write")
+            return qsTr("&Download")
+        return qsTr("&Download && Write")
     }
 
     onPreviousButtonClicked: {

--- a/src/app/qml/MainPage.qml
+++ b/src/app/qml/MainPage.qml
@@ -28,26 +28,28 @@ Page {
     imageSource: "qrc:/mainPageImage"
     text: qsTr("Select Image Source")
 
-    QQC2.RadioButton {
+    MnemonicRadioButton {
+        id: downloadRadio
         checked: selectedOption == Units.MainSelect.Download
-        text: qsTr("Download automatically")
+        mnemonicText: qsTr("<u>D</u>ownload automatically")
         onClicked: {
             selectedOption = Units.MainSelect.Download
         }
     }
 
-    QQC2.RadioButton {
-        text: qsTr("Select .iso file")
+    MnemonicRadioButton {
+        id: adoptIsoRadio
+        mnemonicText: qsTr("<u>S</u>elect .iso file")
         onClicked: {
             selectedOption = Units.MainSelect.Write
             releases.selectLocalFile("")
         }
     }
 
-    QQC2.RadioButton {
+    MnemonicRadioButton {
         id: restoreRadio
         visible: drives.restoreableDrives.length > 0
-        text: drives.restoreableDrives.length === 1 ? qsTr("Restore <b>%1</b>").arg(drives.restoreableDrives[0].name) : qsTr("Restore a USB drive (%1 available)").arg(drives.restoreableDrives.length)
+        mnemonicText: drives.restoreableDrives.length === 1 ? qsTr("<u>R</u>estore <b>%1</b>").arg(drives.restoreableDrives[0].name) : qsTr("<u>R</u>estore a USB drive (%1 available)").arg(drives.restoreableDrives.length)
         onClicked: {
             selectedOption = Units.MainSelect.Restore
         }
@@ -59,7 +61,7 @@ Page {
         Layout.fillHeight: true
     }
 
-    previousButtonText: qsTr("About")
+    previousButtonText: qsTr("<u>A</u>bout")
 
     onPreviousButtonClicked: {
         aboutDialog.open()

--- a/src/app/qml/MainPage.qml
+++ b/src/app/qml/MainPage.qml
@@ -31,7 +31,7 @@ Page {
     MnemonicRadioButton {
         id: downloadRadio
         checked: selectedOption == Units.MainSelect.Download
-        mnemonicText: qsTr("<u>D</u>ownload automatically")
+        mnemonicText: qsTr("&Download automatically")
         onClicked: {
             selectedOption = Units.MainSelect.Download
         }
@@ -39,7 +39,7 @@ Page {
 
     MnemonicRadioButton {
         id: adoptIsoRadio
-        mnemonicText: qsTr("<u>S</u>elect .iso file")
+        mnemonicText: qsTr("&Select .iso file")
         onClicked: {
             selectedOption = Units.MainSelect.Write
             releases.selectLocalFile("")
@@ -49,7 +49,7 @@ Page {
     MnemonicRadioButton {
         id: restoreRadio
         visible: drives.restoreableDrives.length > 0
-        mnemonicText: drives.restoreableDrives.length === 1 ? qsTr("<u>R</u>estore <b>%1</b>").arg(drives.restoreableDrives[0].name) : qsTr("<u>R</u>estore a USB drive (%1 available)").arg(drives.restoreableDrives.length)
+        mnemonicText: drives.restoreableDrives.length === 1 ? qsTr("&Restore <b>%1</b>").arg(drives.restoreableDrives[0].name) : qsTr("&Restore a USB drive (%1 available)").arg(drives.restoreableDrives.length)
         onClicked: {
             selectedOption = Units.MainSelect.Restore
         }
@@ -61,7 +61,7 @@ Page {
         Layout.fillHeight: true
     }
 
-    previousButtonText: qsTr("<u>A</u>bout")
+    previousButtonText: qsTr("&About")
 
     onPreviousButtonClicked: {
         aboutDialog.open()

--- a/src/app/qml/MnemonicButton.qml
+++ b/src/app/qml/MnemonicButton.qml
@@ -23,21 +23,16 @@ import QtQuick.Controls as QQC2
 QQC2.Button {
     id: control
 
-    property string mnemonicText: ""
-    property string shortcutSequence: {
-        var text = mnemonicText.match(/<u>(.)<\/u>/i)
-        return text ? "Alt+" + text[1].toUpperCase() : ""
-    }
-    property bool shortcutActive: true
+    property alias mnemonicText: handler.mnemonicText
+    property alias shortcutActive: handler.shortcutActive
 
-    text: mainWindow.mnemonic(mnemonicText)
+    signal mnemonicActivated()
 
-    Shortcut {
-        sequence: control.shortcutSequence
-        enabled: control.shortcutSequence !== ""
-                 && control.shortcutActive
-                 && control.visible
-                 && control.enabled
-        onActivated: control.clicked()
+    text: handler.displayText
+    onMnemonicActivated: control.clicked()
+
+    MnemonicHandler {
+        id: handler
+        target: control
     }
 }

--- a/src/app/qml/MnemonicButton.qml
+++ b/src/app/qml/MnemonicButton.qml
@@ -1,0 +1,43 @@
+/*
+ * Fedora Media Writer
+ * Copyright (C) 2024 Jan Grulich <jgrulich@redhat.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+import QtQuick
+import QtQuick.Controls as QQC2
+
+QQC2.Button {
+    id: control
+
+    property string mnemonicText: ""
+    property string shortcutSequence: {
+        var text = mnemonicText.match(/<u>(.)<\/u>/i)
+        return text ? "Alt+" + text[1].toUpperCase() : ""
+    }
+    property bool shortcutActive: true
+
+    text: mainWindow.mnemonic(mnemonicText)
+
+    Shortcut {
+        sequence: control.shortcutSequence
+        enabled: control.shortcutSequence !== ""
+                 && control.shortcutActive
+                 && control.visible
+                 && control.enabled
+        onActivated: control.clicked()
+    }
+}

--- a/src/app/qml/MnemonicCheckBox.qml
+++ b/src/app/qml/MnemonicCheckBox.qml
@@ -1,0 +1,43 @@
+/*
+ * Fedora Media Writer
+ * Copyright (C) 2024 Jan Grulich <jgrulich@redhat.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+import QtQuick
+import QtQuick.Controls as QQC2
+
+QQC2.CheckBox {
+    id: control
+
+    property string mnemonicText: ""
+    property string shortcutSequence: {
+        var text = mnemonicText.match(/<u>(.)<\/u>/i)
+        return text ? "Alt+" + text[1].toUpperCase() : ""
+    }
+    property bool shortcutActive: true
+
+    text: mainWindow.mnemonic(mnemonicText)
+
+    Shortcut {
+        sequence: control.shortcutSequence
+        enabled: control.shortcutSequence !== ""
+                 && control.shortcutActive
+                 && control.visible
+                 && control.enabled
+        onActivated: control.toggle()
+    }
+}

--- a/src/app/qml/MnemonicHandler.qml
+++ b/src/app/qml/MnemonicHandler.qml
@@ -18,21 +18,27 @@
  */
 
 import QtQuick
-import QtQuick.Controls as QQC2
 
-QQC2.CheckBox {
-    id: control
+Item {
+    id: handler
 
-    property alias mnemonicText: handler.mnemonicText
-    property alias shortcutActive: handler.shortcutActive
+    property string mnemonicText: ""
+    property string shortcutSequence: {
+        var match = mnemonicText.match(/&(\w)/)
+        return match ? "Alt+" + match[1].toUpperCase() : ""
+    }
+    property bool shortcutActive: true
+    property var target: null
 
-    signal mnemonicActivated()
+    readonly property string displayText: mainWindow.mnemonic(mnemonicText)
 
-    text: handler.displayText
-    onMnemonicActivated: control.toggle()
-
-    MnemonicHandler {
-        id: handler
-        target: control
+    Shortcut {
+        sequence: handler.shortcutSequence
+        enabled: handler.shortcutSequence !== ""
+                 && handler.shortcutActive
+                 && handler.target
+                 && handler.target.visible
+                 && handler.target.enabled
+        onActivated: handler.target.mnemonicActivated()
     }
 }

--- a/src/app/qml/MnemonicRadioButton.qml
+++ b/src/app/qml/MnemonicRadioButton.qml
@@ -23,24 +23,19 @@ import QtQuick.Controls as QQC2
 QQC2.RadioButton {
     id: control
 
-    property string mnemonicText: ""
-    property string shortcutSequence: {
-        var text = mnemonicText.match(/<u>(.)<\/u>/i)
-        return text ? "Alt+" + text[1].toUpperCase() : ""
+    property alias mnemonicText: handler.mnemonicText
+    property alias shortcutActive: handler.shortcutActive
+
+    signal mnemonicActivated()
+
+    text: handler.displayText
+    onMnemonicActivated: {
+        control.checked = true
+        control.clicked()
     }
-    property bool shortcutActive: true
 
-    text: mainWindow.mnemonic(mnemonicText)
-
-    Shortcut {
-        sequence: control.shortcutSequence
-        enabled: control.shortcutSequence !== ""
-                 && control.shortcutActive
-                 && control.visible
-                 && control.enabled
-        onActivated: {
-            control.checked = true
-            control.clicked()
-        }
+    MnemonicHandler {
+        id: handler
+        target: control
     }
 }

--- a/src/app/qml/MnemonicRadioButton.qml
+++ b/src/app/qml/MnemonicRadioButton.qml
@@ -1,0 +1,46 @@
+/*
+ * Fedora Media Writer
+ * Copyright (C) 2024 Jan Grulich <jgrulich@redhat.com>
+ *
+ * This program is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU General Public License
+ * as published by the Free Software Foundation; either version 2
+ * of the License, or (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
+ */
+
+import QtQuick
+import QtQuick.Controls as QQC2
+
+QQC2.RadioButton {
+    id: control
+
+    property string mnemonicText: ""
+    property string shortcutSequence: {
+        var text = mnemonicText.match(/<u>(.)<\/u>/i)
+        return text ? "Alt+" + text[1].toUpperCase() : ""
+    }
+    property bool shortcutActive: true
+
+    text: mainWindow.mnemonic(mnemonicText)
+
+    Shortcut {
+        sequence: control.shortcutSequence
+        enabled: control.shortcutSequence !== ""
+                 && control.shortcutActive
+                 && control.visible
+                 && control.enabled
+        onActivated: {
+            control.checked = true
+            control.clicked()
+        }
+    }
+}

--- a/src/app/qml/Page.qml
+++ b/src/app/qml/Page.qml
@@ -96,7 +96,7 @@ QQC2.Page {
 
             MnemonicButton {
                 id: prevButton
-                mnemonicText: qsTr("<u>P</u>revious")
+                mnemonicText: qsTr("&Previous")
                 onClicked: previousButtonClicked()
             }
 
@@ -106,7 +106,7 @@ QQC2.Page {
 
             MnemonicButton {
                 id: nextButton
-                mnemonicText: qsTr("<u>N</u>ext")
+                mnemonicText: qsTr("&Next")
                 onClicked: nextButtonClicked()
             }
         }

--- a/src/app/qml/Page.qml
+++ b/src/app/qml/Page.qml
@@ -33,8 +33,8 @@ QQC2.Page {
     property alias layoutSpacing: layout.spacing
 
     // Button.Text
-    property alias previousButtonText: prevButton.text
-    property alias nextButtonText: nextButton.text
+    property alias previousButtonText: prevButton.mnemonicText
+    property alias nextButtonText: nextButton.mnemonicText
 
     // Button.Visible
     property alias previousButtonVisible: prevButton.visible
@@ -94,9 +94,9 @@ QQC2.Page {
 
             Layout.alignment: Qt.AlignBottom
 
-            QQC2.Button {
+            MnemonicButton {
                 id: prevButton
-                text: qsTr("Previous")
+                mnemonicText: qsTr("<u>P</u>revious")
                 onClicked: previousButtonClicked()
             }
 
@@ -104,10 +104,10 @@ QQC2.Page {
                 Layout.fillWidth: true
             }
 
-            QQC2.Button {
+            MnemonicButton {
                 id: nextButton
-                text: qsTr("Next")
-                onClicked: nextButtonClicked();
+                mnemonicText: qsTr("<u>N</u>ext")
+                onClicked: nextButtonClicked()
             }
         }
     }

--- a/src/app/qml/RestorePage.qml
+++ b/src/app/qml/RestorePage.qml
@@ -136,7 +136,7 @@ Page {
                                          selectedDrive.restoreStatus == Units.RestoreStatus.Contains_Live)
     nextButtonVisible: selectedDrive && selectedDrive.restoreStatus != Units.RestoreStatus.Restoring
     nextButtonText: selectedDrive && (selectedDrive.restoreStatus == Units.RestoreStatus.Restored ||
-                                      selectedDrive.restoreStatus == Units.RestoreStatus.Restore_Error) ? qsTr("Finish") : qsTr("Restore")
+                                      selectedDrive.restoreStatus == Units.RestoreStatus.Restore_Error) ? qsTr("<u>F</u>inish") : qsTr("<u>R</u>estore")
     onNextButtonClicked: {
         if (selectedDrive.restoreStatus == Units.RestoreStatus.Restored ||
             selectedDrive.restoreStatus == Units.RestoreStatus.Restore_Error) {

--- a/src/app/qml/RestorePage.qml
+++ b/src/app/qml/RestorePage.qml
@@ -136,7 +136,7 @@ Page {
                                          selectedDrive.restoreStatus == Units.RestoreStatus.Contains_Live)
     nextButtonVisible: selectedDrive && selectedDrive.restoreStatus != Units.RestoreStatus.Restoring
     nextButtonText: selectedDrive && (selectedDrive.restoreStatus == Units.RestoreStatus.Restored ||
-                                      selectedDrive.restoreStatus == Units.RestoreStatus.Restore_Error) ? qsTr("<u>F</u>inish") : qsTr("<u>R</u>estore")
+                                      selectedDrive.restoreStatus == Units.RestoreStatus.Restore_Error) ? qsTr("&Finish") : qsTr("&Restore")
     onNextButtonClicked: {
         if (selectedDrive.restoreStatus == Units.RestoreStatus.Restored ||
             selectedDrive.restoreStatus == Units.RestoreStatus.Restore_Error) {

--- a/src/app/qml/VersionPage.qml
+++ b/src/app/qml/VersionPage.qml
@@ -32,24 +32,28 @@ Page {
         text: qsTr("Select from:")
     }
 
-    QQC2.RadioButton {
+    MnemonicRadioButton {
+        id: officialRadio
         checked: true
-        text: qsTr("Official Editions")
+        mnemonicText: qsTr("<u>O</u>fficial Editions")
         onClicked: changeFilter(Units.Source.Product)
     }
 
-    QQC2.RadioButton {
-        text: qsTr("Atomic Desktops")
+    MnemonicRadioButton {
+        id: atomicosRadio
+        mnemonicText: qsTr("<u>A</u>tomic Desktops")
         onClicked: changeFilter(Units.Source.Emerging)
     }
 
-    QQC2.RadioButton {
-        text: qsTr("Spins")
+    MnemonicRadioButton {
+        id: fedospinRadio
+        mnemonicText: qsTr("<u>S</u>pins")
         onClicked: changeFilter(Units.Source.Spins)
     }
 
-    QQC2.RadioButton {
-        text: qsTr("Labs")
+    MnemonicRadioButton {
+        id: fedolabsRadio
+        mnemonicText: qsTr("<u>L</u>abs")
         onClicked: changeFilter(Units.Source.Labs)
     }
 

--- a/src/app/qml/VersionPage.qml
+++ b/src/app/qml/VersionPage.qml
@@ -35,25 +35,25 @@ Page {
     MnemonicRadioButton {
         id: officialRadio
         checked: true
-        mnemonicText: qsTr("<u>O</u>fficial Editions")
+        mnemonicText: qsTr("&Official Editions")
         onClicked: changeFilter(Units.Source.Product)
     }
 
     MnemonicRadioButton {
         id: atomicosRadio
-        mnemonicText: qsTr("<u>A</u>tomic Desktops")
+        mnemonicText: qsTr("&Atomic Desktops")
         onClicked: changeFilter(Units.Source.Emerging)
     }
 
     MnemonicRadioButton {
         id: fedospinRadio
-        mnemonicText: qsTr("<u>S</u>pins")
+        mnemonicText: qsTr("&Spins")
         onClicked: changeFilter(Units.Source.Spins)
     }
 
     MnemonicRadioButton {
         id: fedolabsRadio
-        mnemonicText: qsTr("<u>L</u>abs")
+        mnemonicText: qsTr("&Labs")
         onClicked: changeFilter(Units.Source.Labs)
     }
 

--- a/src/app/qml/main.qml
+++ b/src/app/qml/main.qml
@@ -37,6 +37,11 @@ ApplicationWindow {
     property int selectedVersion: Units.Source.Product
     property int selectedOption: Units.MainSelect.Download
     property bool eraseVariant: false
+    property bool altPressed: mnemonicFilter.altPressed
+
+    function mnemonic(text) {
+        return altPressed ? text : text.replace(/<\/?u>/g, "")
+    }
     
     StackView {
         id: stackView

--- a/src/app/qml/main.qml
+++ b/src/app/qml/main.qml
@@ -40,7 +40,9 @@ ApplicationWindow {
     property bool altPressed: mnemonicFilter.altPressed
 
     function mnemonic(text) {
-        return altPressed ? text : text.replace(/<\/?u>/g, "")
+        if (altPressed)
+            return text.replace(/&(\w)/, "<u>$1</u>")
+        return text.replace(/&(\w)/, "$1")
     }
     
     StackView {


### PR DESCRIPTION
feat(qml): add keyboard mnemonics for accessible navigation

Fixes #643

Here are some screenshots

<img width="662" height="540" alt="image" src="https://github.com/user-attachments/assets/1037c9ef-410f-4106-82c0-ebb439818440" />

Use `Alt+D` and `Alt+S` for the radio buttons, and `Alt+A` and `Alt+N` for the push buttons.

<img width="662" height="540" alt="image" src="https://github.com/user-attachments/assets/9ebc1ea3-3767-4e76-bca9-49c34135a96a" />

Use `Alt+O`, `Alt+A`, `Alt+S` and `Alt+L` for the radio buttons, and `Alt+P` and `Alt+N` for the push buttons.

<img width="662" height="540" alt="image" src="https://github.com/user-attachments/assets/b2ed8b37-df67-4632-9449-3c6fac55ab7b" />

Use `Alt+L` for the check boxes, and `Alt+P` and `Alt+D` for the push buttons.

For wherever these pnemonics are not possible, simply use the `Tab` button I guess.