### PR TITLE
Resolve annoying cmake_minimum_required warning

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,10 +1,10 @@
+cmake_minimum_required(VERSION 3.17)
+
 if(APPLE)
     set(CMAKE_OSX_DEPLOYMENT_TARGET "13.0" CACHE STRING "Minimum OS X deployment version")
 endif()
 
 project(MediaWriter)
-
-cmake_minimum_required(VERSION 3.17)
 
 set(MEDIAWRITER_MAJOR_VERSION "5")
 set(MEDIAWRITER_MINOR_VERSION "3")


### PR DESCRIPTION
# Justification
Whenever I update this tool through AUR I see this warning message, it bothers me.

```txt
CMake Warning (dev) at CMakeLists.txt:5 (project):
  cmake_minimum_required() should be called prior to this top-level project()
  call.  Please see the cmake-commands(7) manual for usage documentation of
  both commands.
This warning is for project developers.  Use -Wno-dev to suppress it.
```

# Implementation
Moved the line at the top of the file.

# Testing
N\A